### PR TITLE
Fix union model namespace

### DIFF
--- a/src/Models/Union.php
+++ b/src/Models/Union.php
@@ -1,6 +1,6 @@
 <?php
 
-namespace App\Models;
+namespace Devfaysal\BangladeshGeocode\Models;
 
 use Illuminate\Database\Eloquent\Model;
 


### PR DESCRIPTION
This is as simple as the title suggests.

It has a wrong namespace defined in the Union model. The PR simply fixes it.
